### PR TITLE
Feature: Tests for Potluck Endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,40 @@ _Response_
 }
 ```
 
+### [POST] /api/users/:user_id/potlucks
+- Creates new potluck object by individual users
+  - _potluck_name required_
+  - _date required_
+  - _time required_
+  - _location required_
+
+_Send_
+```json
+{
+ "potluck_name": "potluck 1",
+ "date": "2021/12/21",
+ "time": "12:00",
+ "location": "nowhere"
+}
+```
+_Response_
+```json
+{
+ "potluck_name": "potluck 1",
+ "date": "2021/12/21",
+ "time": "12:00",
+ "location": "nowhere",
+ "user_id": 1,
+ "guests": [
+  {
+    "user_id": 1,
+    "username": "user",
+    "attending": true,
+  }
+ ]
+}
+```
+
 ## POTLUCKS _(RESTRICTED)_
 
 ### [GET] /api/potlucks
@@ -109,8 +143,8 @@ _Response_
   {
     "potluck_id": 1,
     "potluck_name": "potluck 1",
-    "date": "2021-12-21",,
-    "time": "11:00:00",
+    "date": "2021/12/21",,
+    "time": "11:00",
     "location": "america",
     "user_id": 1
   }
@@ -124,8 +158,8 @@ _Response_
   {
     "potluck_id": 1,
     "potluck_name": "potluck 1",
-    "date": "2021-12-21",,
-    "time": "11:00:00",
+    "date": "2021/12/21",,
+    "time": "11:00",
     "location": "america",
     "user_id": 1
     "guests": [
@@ -152,14 +186,19 @@ _Response_
 [
  {
   "user_id": 1,
-  "username": "user",
+  "username": "user1",
   "attending": true
+ },
+ {
+  "user_id": 3,
+  "username": "user3",
+  "attending": false
  }
 ]
 ```
 ### [GET] /api/potlucks/:potluck_id/foods
 
-- Returns array of food by potluck ID
+- Returns an array of food by potluck ID
 
 ```json
 [
@@ -170,51 +209,25 @@ _Response_
  }
 ]
 ```
-### [POST] /api/users/:user_id/potlucks
-- Creates new potluck object by individual users
-  - _potluck_name required_
-  - _date required_
-  - _time required_
-  - _location required_
 
-_Send_
-```json
-{
- "potluck_name": "potluck 1",
- "date": "2021-12-21",
- "time": "12:00:00",
- "location": "nowhere"
-}
-```
-_Response_
-```json
-{
- "potluck_name": "potluck 1",
- "date": "2021-12-21",
- "time": "12:00:00",
- "location": "nowhere"
- "user_id": 1,
- "guests": [
-  {
-    "user_id": 1,
-    "username": "user",
-    "attending": true,
-  }
- ]
-}
-```
 ### [POST] /api/potlucks/:potluck_id/guests
 
-- Add guests by potluck ID
+- Add an array of guests by potluck ID
   - _user_id required_
   - _attending required_
 
 _Send_
 ```json
-{
- "user_id": 1,
- "attending": true
-}
+[
+  {
+   "user_id": 1,
+   "attending": true
+  },
+  {
+   "user_id": 2,
+   "attending": false
+  }
+]
 ```
 
 _Response_
@@ -226,8 +239,8 @@ _Response_
 }
 ```
 
-## [POST] /api/potlucks/:potluck_id/foods
-- Add food by potluck ID
+### [POST] /api/potlucks/:potluck_id/foods
+- Adds a food to a potluck
   - food_name required
 
 _Send_

--- a/api/data/seeds/02-users.js
+++ b/api/data/seeds/02-users.js
@@ -6,6 +6,7 @@ const users = [
   { username: "frodo", password: bcrypt.hashSync("1234", BCRYPT_ROUNDS) },
   { username: "pippin", password: bcrypt.hashSync("1234", BCRYPT_ROUNDS) },
   { username: "merry", password: bcrypt.hashSync("1234", BCRYPT_ROUNDS) },
+  { username: "tom", password: bcrypt.hashSync("1234", BCRYPT_ROUNDS) },
 ]
 
 exports.seed = function (knex) {

--- a/api/data/seeds/03-potlucks.js
+++ b/api/data/seeds/03-potlucks.js
@@ -5,7 +5,8 @@ const {
 
 const potluckDates = [
   new Date(Date.UTC(2022, 2, 3, 13, 30)),
-  new Date(Date.UTC(2022, 1, 12, 14, 30))
+  new Date(Date.UTC(2022, 1, 12, 14, 30)),
+  new Date(Date.UTC(2022, 4, 9, 18, 0))
 ]
 
 const potlucks = [
@@ -22,6 +23,13 @@ const potlucks = [
     time: getTime(potluckDates[1]),
     location: "The Shire",
     user_id: 3
+  },
+  {
+    potluck_name: "Tom's Roarin' Dusk Feast",
+    date: getDate(potluckDates[2]),
+    time: getTime(potluckDates[2]),
+    location: "Gondor",
+    user_id: 5
   },
 ]
 

--- a/api/data/seeds/06-guests.js
+++ b/api/data/seeds/06-guests.js
@@ -1,13 +1,11 @@
 const guests = [
   // Potluck 1
   { food_potluck_id: 1, potluck_id: 1, user_id: 1, attending: true },
-  { food_potluck_id: 1, potluck_id: 1, user_id: 2, attending: false },
   { food_potluck_id: 2, potluck_id: 1, user_id: 3, attending: true },
-  { food_potluck_id: 3, potluck_id: 1, user_id: 4, attending: true },
+  { food_potluck_id: 3, potluck_id: 1, user_id: 4, attending: false },
   // Potluck 2
-  { food_potluck_id: 2, potluck_id: 2, user_id: 1, attending: true },
-  { food_potluck_id: 4, potluck_id: 2, user_id: 2, attending: true },
-  { food_potluck_id: 5, potluck_id: 2, user_id: 3, attending: false },
+  { food_potluck_id: 5, potluck_id: 2, user_id: 1, attending: true },
+  { food_potluck_id: 4, potluck_id: 2, user_id: 2, attending: false },
   { food_potluck_id: 6, potluck_id: 2, user_id: 4, attending: true },
 ]
 

--- a/api/potlucks/potluck-middleware.js
+++ b/api/potlucks/potluck-middleware.js
@@ -36,6 +36,7 @@ async function validateAddGuestPayload(req, res, next) {
   const potluck = await Potlucks.getById(req.params.potluck_id)
   if (potluck.user_id === user_id) {
     return next({
+      status: 400,
       message: "Cannot add a potluck organizer as their own guest"
     })
   }

--- a/api/potlucks/potluck-middleware.js
+++ b/api/potlucks/potluck-middleware.js
@@ -1,4 +1,5 @@
 const Potlucks = require('./potlucks-model');
+const Users = require("../users/users-model")
 
 const checkPotluckId = async (req, res, next) => {
   try {
@@ -17,4 +18,29 @@ const checkPotluckId = async (req, res, next) => {
   }
 };
 
-module.exports = { checkPotluckId };
+async function validateAddGuestPayload(req, res, next) {
+  const { user_id, attending } = req.body
+  if (!user_id || !attending || typeof attending !== "boolean") {
+    next({
+      status: 400,
+      message: "Please provide a user_id and an attending boolean"
+    })
+  }
+  const existingUser = await Users.getById(user_id)
+  if (!existingUser) {
+    return next({
+      status: 404,
+      message: `User with id of ${user_id} does not exist`
+    })
+  }
+  req.body.guest = {
+    user_id: existingUser.user_id,
+    attending: req.body.attending
+  }
+  return next()
+}
+
+module.exports = {
+  checkPotluckId,
+  validateAddGuestPayload
+};

--- a/api/potlucks/potluck-middleware.js
+++ b/api/potlucks/potluck-middleware.js
@@ -21,7 +21,7 @@ const checkPotluckId = async (req, res, next) => {
 async function validateAddGuestPayload(req, res, next) {
   const { user_id, attending } = req.body
   if (!user_id || !attending || typeof attending !== "boolean") {
-    next({
+    return next({
       status: 400,
       message: "Please provide a user_id and an attending boolean"
     })
@@ -31,6 +31,12 @@ async function validateAddGuestPayload(req, res, next) {
     return next({
       status: 404,
       message: `User with id of ${user_id} does not exist`
+    })
+  }
+  const potluck = await Potlucks.getById(req.params.potluck_id)
+  if (potluck.user_id === user_id) {
+    return next({
+      message: "Cannot add a potluck organizer as their own guest"
     })
   }
   req.body.guest = {

--- a/api/potlucks/potluck-router.test.js
+++ b/api/potlucks/potluck-router.test.js
@@ -97,4 +97,18 @@ describe("[GET] - /api/potlucks/:potluck_id", () => {
       expect(res.status).toBe(200)
     })
   })
+  describe("requesting with no token", () => {
+    let res
+    beforeEach(async () => {
+      res = await request(server)
+        .get("/api/potlucks/2")
+    })
+    it("responds with the message 'token required'", () => {
+      const expected = /token required/i
+      expect(res.body.message).toMatch(expected)
+    })
+    it("responds with the status code 401", () => {
+      expect(res.status).toBe(401)
+    })
+  })
 })

--- a/api/potlucks/potluck-router.test.js
+++ b/api/potlucks/potluck-router.test.js
@@ -47,8 +47,26 @@ describe("[GET] /api/potlucks", () => {
         .get("/api/potlucks")
     })
     it("responds with the message 'token required'", () => {
-      const expected = "token required"
+      const expected = /token required/i
       expect(res.body.message).toMatch(expected)
+    })
+    it("responds with the status code 401", () => {
+      expect(res.status).toBe(401)
+    })
+  })
+  describe("invalid token", () => {
+    let res
+    beforeEach(async () => {
+      res = await request(server)
+        .get("/api/potlucks")
+        .set("Authorization", "junk")
+    })
+    it("responds with the message 'token required'", () => {
+      const expected = /invalid token/i
+      expect(res.body.message).toMatch(expected)
+    })
+    it("responds with the status code 401", () => {
+      expect(res.status).toBe(401)
     })
   })
 })

--- a/api/potlucks/potluck-router.test.js
+++ b/api/potlucks/potluck-router.test.js
@@ -434,4 +434,43 @@ describe("[POST] - /api/potlucks/:potluck_id/guests", () => {
       })
     })
   })
+
+  describe("requesting with no token", () => {
+    let res
+    beforeAll(async () => {
+      res = await request(server)
+        .post("/api/potlucks/3/guests")
+        .send({
+          user_id: 4,
+          attending: true
+        })
+    })
+    it("responds with the message 'token required'", () => {
+      const expected = /token required/i
+      expect(res.body.message).toMatch(expected)
+    })
+    it("responds with the status code 401", () => {
+      expect(res.status).toBe(401)
+    })
+  })
+
+  describe("requesting with an invalid token", () => {
+    let res
+    beforeAll(async () => {
+      res = await request(server)
+        .post("/api/potlucks/3/guests")
+        .send({
+          user_id: 1,
+          attending: true
+        })
+        .set("Authorization", "ultraJunk")
+    })
+    it("responds with the message 'invalid token'", () => {
+      const expected = /invalid token/i
+      expect(res.body.message).toMatch(expected)
+    })
+    it("responds with the status code 401", () => {
+      expect(res.status).toBe(401)
+    })
+  })
 })

--- a/api/potlucks/potluck-router.test.js
+++ b/api/potlucks/potluck-router.test.js
@@ -13,8 +13,8 @@ afterAll(async () => {
   await db.destroy()
 })
 
-describe("[GET] /api/potlucks", () => {
-  describe("success", () => {
+describe("[GET] - /api/potlucks", () => {
+  describe("requesting with a valid token", () => {
     let res
     beforeEach(async () => {
       const loginRes = await request(server)
@@ -40,7 +40,7 @@ describe("[GET] /api/potlucks", () => {
       expect(res.status).toBe(200)
     })
   })
-  describe("token required", () => {
+  describe("requesting with no token", () => {
     let res
     beforeEach(async () => {
       res = await request(server)
@@ -54,7 +54,7 @@ describe("[GET] /api/potlucks", () => {
       expect(res.status).toBe(401)
     })
   })
-  describe("invalid token", () => {
+  describe("requesting with an invalid token", () => {
     let res
     beforeEach(async () => {
       res = await request(server)
@@ -67,6 +67,34 @@ describe("[GET] /api/potlucks", () => {
     })
     it("responds with the status code 401", () => {
       expect(res.status).toBe(401)
+    })
+  })
+})
+
+describe("[GET] - /api/potlucks/:potluck_id", () => {
+  describe("requesting with a valid token", () => {
+    let res
+    beforeEach(async () => {
+      const loginRes = await request(server)
+        .post("/api/auth/login")
+        .send({
+          username: "PiPPiN",
+          password: "1234"
+        })
+      res = await request(server)
+        .get("/api/potlucks/2")
+        .set("Authorization", loginRes.body.token)
+    })
+    it("responds with a single potluck object if request headers authorization is valid", () => {
+      expect(res.body).toHaveProperty("date")
+      expect(res.body).toHaveProperty("location")
+      expect(res.body).toHaveProperty("time")
+      expect(res.body).toHaveProperty("potluck_name")
+      expect(res.body).toHaveProperty("potluck_id", 2)
+      expect(res.body).toHaveProperty("user_id", 3)
+    })
+    it("responds with the status code 200", () => {
+      expect(res.status).toBe(200)
     })
   })
 })

--- a/api/potlucks/potluck-router.test.js
+++ b/api/potlucks/potluck-router.test.js
@@ -286,4 +286,35 @@ describe("[GET] - /api/potlucks/:potluck_id/foods", () => {
       })
     })
   })
+
+  describe("requesting with no token", () => {
+    let res
+    beforeEach(async () => {
+      res = await request(server)
+        .get("/api/potlucks/1/foods")
+    })
+    it("responds with the message 'token required'", () => {
+      const expected = /token required/i
+      expect(res.body.message).toMatch(expected)
+    })
+    it("responds with the status code 401", () => {
+      expect(res.status).toBe(401)
+    })
+  })
+
+  describe("requesting with an invalid token", () => {
+    let res
+    beforeEach(async () => {
+      res = await request(server)
+        .get("/api/potlucks/1/foods")
+        .set("Authorization", "ultraJunk")
+    })
+    it("responds with the message 'invalid token'", () => {
+      const expected = /invalid token/i
+      expect(res.body.message).toMatch(expected)
+    })
+    it("responds with the status code 401", () => {
+      expect(res.status).toBe(401)
+    })
+  })
 })

--- a/api/potlucks/potluck-router.test.js
+++ b/api/potlucks/potluck-router.test.js
@@ -30,13 +30,16 @@ describe("[GET] - /api/potlucks", () => {
         .set("Authorization", loginRes.body.token)
     })
     it("responds with an array of potlucks", () => {
-      expect(res.body).toHaveLength(2)
-      expect(res.body[0] && res.body[1]).toHaveProperty("date")
-      expect(res.body[0] && res.body[1]).toHaveProperty("location")
-      expect(res.body[0] && res.body[1]).toHaveProperty("time")
-      expect(res.body[0] && res.body[1]).toHaveProperty("potluck_name")
-      expect(res.body[0] && res.body[1]).toHaveProperty("potluck_id")
-      expect(res.body[0] && res.body[1]).toHaveProperty("user_id")
+      const actual = res.body
+      expect(actual).toHaveLength(3)
+      actual.forEach(potluck => {
+        expect(potluck).toHaveProperty("date")
+        expect(potluck).toHaveProperty("location")
+        expect(potluck).toHaveProperty("time")
+        expect(potluck).toHaveProperty("potluck_name")
+        expect(potluck).toHaveProperty("potluck_id")
+        expect(potluck).toHaveProperty("user_id")
+      })
     })
     it("responds with the status code 200", () => {
       expect(res.status).toBe(200)
@@ -106,15 +109,15 @@ describe("[GET] - /api/potlucks/:potluck_id", () => {
       expect(res.status).toBe(200)
     })
 
-    describe("requesting a nonexistent potluck", () => {
+    describe("to get a nonexistent potluck", () => {
       let res
       beforeEach(async () => {
         res = await request(server)
-          .get("/api/potlucks/3")
+          .get("/api/potlucks/8")
           .set("Authorization", loginRes.body.token)
       })
       it("responds with 'potluck with id _#_ not found'", () => {
-        const expected = /potluck with id 3 not found/i
+        const expected = /potluck with id 8 not found/i
         expect(res.body.message).toMatch(expected)
       })
       it("responds with the status code 404", () => {
@@ -188,15 +191,15 @@ describe("[GET] - /api/potlucks/:potluck_id/guests", () => {
       expect(res.status).toBe(200)
     })
 
-    describe("requesting guests from a nonexistent potluck", () => {
+    describe("to get guests from a nonexistent potluck", () => {
       let res
       beforeEach(async () => {
         res = await request(server)
-          .get("/api/potlucks/3/guests")
+          .get("/api/potlucks/8/guests")
           .set("Authorization", loginRes.body.token)
       })
       it("responds with 'potluck with id _#_ not found'", () => {
-        const expected = /potluck with id 3 not found/i
+        const expected = /potluck with id 8 not found/i
         expect(res.body.message).toMatch(expected)
       })
       it("responds with the status code 404", () => {
@@ -270,15 +273,15 @@ describe("[GET] - /api/potlucks/:potluck_id/foods", () => {
       expect(res.status).toBe(200)
     })
 
-    describe("requesting foods from a nonexistent potluck", () => {
+    describe("foods from a nonexistent potluck", () => {
       let res
       beforeEach(async () => {
         res = await request(server)
-          .get("/api/potlucks/3/foods")
+          .get("/api/potlucks/8/foods")
           .set("Authorization", loginRes.body.token)
       })
       it("responds with 'potluck with id _#_ not found'", () => {
-        const expected = /potluck with id 3 not found/i
+        const expected = /potluck with id 8 not found/i
         expect(res.body.message).toMatch(expected)
       })
       it("responds with the status code 404", () => {
@@ -315,6 +318,40 @@ describe("[GET] - /api/potlucks/:potluck_id/foods", () => {
     })
     it("responds with the status code 401", () => {
       expect(res.status).toBe(401)
+    })
+  })
+})
+
+/* ========== [POST] - /api/potlucks/:potluck_id/guests ========== */
+
+describe("[POST] - /api/potlucks/:potluck_id/guests", () => {
+  describe("requesting with a valid token", () => {
+    let loginRes
+    beforeEach(async () => {
+      loginRes = await request(server)
+        .post("/api/auth/login")
+        .send({
+          username: "SaM",
+          password: "1234"
+        })
+    })
+    describe("to add a valid guest to a potluck", () => {
+      it("resonds with the newly created guest object", async () => {
+        const res = await request(server)
+          .post("/api/potlucks/3/guests")
+          .send({
+            user_id: 5,
+            attending: true
+          })
+          .set("Authorization", loginRes.body.token)
+        const actual = res.body
+        expect(actual).toHaveLength(1)
+        actual.forEach(guest => {
+          expect(guest).toHaveProperty("user_id")
+          expect(guest).toHaveProperty("username")
+          expect(guest).toHaveProperty("attending")
+        })
+      })
     })
   })
 })

--- a/api/potlucks/potluck-router.test.js
+++ b/api/potlucks/potluck-router.test.js
@@ -27,7 +27,7 @@ describe("[GET] - /api/potlucks", () => {
         .get("/api/potlucks")
         .set("Authorization", loginRes.body.token)
     })
-    it("responds with an array of potlucks if request headers authorization is valid", () => {
+    it("responds with an array of potlucks", () => {
       expect(res.body).toHaveLength(2)
       expect(res.body[0] && res.body[1]).toHaveProperty("date")
       expect(res.body[0] && res.body[1]).toHaveProperty("location")
@@ -73,19 +73,19 @@ describe("[GET] - /api/potlucks", () => {
 
 describe("[GET] - /api/potlucks/:potluck_id", () => {
   describe("requesting with a valid token", () => {
-    let res
+    let loginRes
     beforeEach(async () => {
-      const loginRes = await request(server)
+      loginRes = await request(server)
         .post("/api/auth/login")
         .send({
           username: "PiPPiN",
           password: "1234"
         })
-      res = await request(server)
+    })
+    it("responds with a single potluck object", async () => {
+      const res = await request(server)
         .get("/api/potlucks/2")
         .set("Authorization", loginRes.body.token)
-    })
-    it("responds with a single potluck object if request headers authorization is valid", () => {
       expect(res.body).toHaveProperty("date")
       expect(res.body).toHaveProperty("location")
       expect(res.body).toHaveProperty("time")
@@ -93,8 +93,26 @@ describe("[GET] - /api/potlucks/:potluck_id", () => {
       expect(res.body).toHaveProperty("potluck_id", 2)
       expect(res.body).toHaveProperty("user_id", 3)
     })
-    it("responds with the status code 200", () => {
+    it("responds with the status code 200", async () => {
+      const res = await request(server)
+        .get("/api/potlucks/2")
+        .set("Authorization", loginRes.body.token)
       expect(res.status).toBe(200)
+    })
+    describe("requesting a nonexistent potluck", () => {
+      let res
+      beforeEach(async () => {
+        res = await request(server)
+          .get("/api/potlucks/3")
+          .set("Authorization", loginRes.body.token)
+      })
+      it("responds with 'potluck with id _#_ not found'", () => {
+        const expected = /potluck with id 3 not found/i
+        expect(res.body.message).toMatch(expected)
+      })
+      it("responds with the status code 404", () => {
+        expect(res.status).toBe(404)
+      })
     })
   })
   describe("requesting with no token", () => {
@@ -124,6 +142,29 @@ describe("[GET] - /api/potlucks/:potluck_id", () => {
     })
     it("responds with the status code 401", () => {
       expect(res.status).toBe(401)
+    })
+  })
+})
+
+describe("[GET] - /api/potlucks/:potluck_id/guests", () => {
+  describe("requesting with a valid token", () => {
+    let res
+    beforeEach(async () => {
+      const loginRes = await request(server)
+        .post("/api/auth/login")
+        .send({
+          username: "FrOdO",
+          password: "1234"
+        })
+      res = await request(server)
+        .get("/api/potlucks/1/guests")
+        .set("Authorization", loginRes.body.token)
+    })
+    it("responds with an array containing guests objects connected to the specified potluck", () => {
+
+    })
+    it("responds with the status code 200", () => {
+      expect(res.status).toBe(200)
     })
   })
 })

--- a/api/potlucks/potluck-router.test.js
+++ b/api/potlucks/potluck-router.test.js
@@ -236,3 +236,54 @@ describe("[GET] - /api/potlucks/:potluck_id/guests", () => {
     })
   })
 })
+
+/* ========== [GET] - /api/potlucks/:potluck_id/foods ========== */
+
+describe("[GET] - /api/potlucks/:potluck_id/foods", () => {
+  describe("requesting with a valid token", () => {
+    let loginRes
+    beforeEach(async () => {
+      loginRes = await request(server)
+        .post("/api/auth/login")
+        .send({
+          username: "meRRy",
+          password: "1234"
+        })
+    })
+    it("responds with an array containing food objects connected to the specified potluck", async () => {
+      const res = await request(server)
+        .get("/api/potlucks/1/foods")
+        .set("Authorization", loginRes.body.token)
+      const expectedLength = 3
+      const actual = res.body
+      expect(actual).toHaveLength(expectedLength)
+      actual.forEach(food => {
+        expect(food).toHaveProperty("food_name")
+        expect(food).toHaveProperty("user_id")
+        expect(food).toHaveProperty("username")
+      })
+    })
+    it("responds with the status code 200", async () => {
+      const res = await request(server)
+        .get("/api/potlucks/1/foods")
+        .set("Authorization", loginRes.body.token)
+      expect(res.status).toBe(200)
+    })
+
+    describe("requesting foods from a nonexistent potluck", () => {
+      let res
+      beforeEach(async () => {
+        res = await request(server)
+          .get("/api/potlucks/3/foods")
+          .set("Authorization", loginRes.body.token)
+      })
+      it("responds with 'potluck with id _#_ not found'", () => {
+        const expected = /potluck with id 3 not found/i
+        expect(res.body.message).toMatch(expected)
+      })
+      it("responds with the status code 404", () => {
+        expect(res.status).toBe(404)
+      })
+    })
+  })
+})

--- a/api/potlucks/potluck-router.test.js
+++ b/api/potlucks/potluck-router.test.js
@@ -13,6 +13,8 @@ afterAll(async () => {
   await db.destroy()
 })
 
+/* ========== [GET] - /api/potlucks ========== */
+
 describe("[GET] - /api/potlucks", () => {
   describe("requesting with a valid token", () => {
     let res
@@ -40,6 +42,7 @@ describe("[GET] - /api/potlucks", () => {
       expect(res.status).toBe(200)
     })
   })
+
   describe("requesting with no token", () => {
     let res
     beforeEach(async () => {
@@ -54,6 +57,7 @@ describe("[GET] - /api/potlucks", () => {
       expect(res.status).toBe(401)
     })
   })
+
   describe("requesting with an invalid token", () => {
     let res
     beforeEach(async () => {
@@ -70,6 +74,8 @@ describe("[GET] - /api/potlucks", () => {
     })
   })
 })
+
+/* ========== [GET] - /api/potlucks/:potluck_id ========== */
 
 describe("[GET] - /api/potlucks/:potluck_id", () => {
   describe("requesting with a valid token", () => {
@@ -99,6 +105,7 @@ describe("[GET] - /api/potlucks/:potluck_id", () => {
         .set("Authorization", loginRes.body.token)
       expect(res.status).toBe(200)
     })
+
     describe("requesting a nonexistent potluck", () => {
       let res
       beforeEach(async () => {
@@ -115,6 +122,7 @@ describe("[GET] - /api/potlucks/:potluck_id", () => {
       })
     })
   })
+
   describe("requesting with no token", () => {
     let res
     beforeEach(async () => {
@@ -129,11 +137,12 @@ describe("[GET] - /api/potlucks/:potluck_id", () => {
       expect(res.status).toBe(401)
     })
   })
+
   describe("requesting with an invalid token", () => {
     let res
     beforeEach(async () => {
       res = await request(server)
-        .get("/api/potlucks/:potluck_id")
+        .get("/api/potlucks/2")
         .set("Authorization", "megaJunk")
     })
     it("responds with the message 'invalid token'", () => {
@@ -145,6 +154,8 @@ describe("[GET] - /api/potlucks/:potluck_id", () => {
     })
   })
 })
+
+/* ========== [GET] - /api/potlucks/:potluck_id/guests ========== */
 
 describe("[GET] - /api/potlucks/:potluck_id/guests", () => {
   describe("requesting with a valid token", () => {
@@ -176,6 +187,7 @@ describe("[GET] - /api/potlucks/:potluck_id/guests", () => {
         .set("Authorization", loginRes.body.token)
       expect(res.status).toBe(200)
     })
+
     describe("requesting guests from a nonexistent potluck", () => {
       let res
       beforeEach(async () => {
@@ -190,6 +202,37 @@ describe("[GET] - /api/potlucks/:potluck_id/guests", () => {
       it("responds with the status code 404", () => {
         expect(res.status).toBe(404)
       })
+    })
+  })
+
+  describe("requesting with no token", () => {
+    let res
+    beforeEach(async () => {
+      res = await request(server)
+        .get("/api/potlucks/1/guests")
+    })
+    it("responds with the message 'token required'", () => {
+      const expected = /token required/i
+      expect(res.body.message).toMatch(expected)
+    })
+    it("responds with the status code 401", () => {
+      expect(res.status).toBe(401)
+    })
+  })
+
+  describe("requesting with an invalid token", () => {
+    let res
+    beforeEach(async () => {
+      res = await request(server)
+        .get("/api/potlucks/1/guests")
+        .set("Authorization", "megaJunk")
+    })
+    it("responds with the message 'invalid token'", () => {
+      const expected = /invalid token/i
+      expect(res.body.message).toMatch(expected)
+    })
+    it("responds with the status code 401", () => {
+      expect(res.status).toBe(401)
     })
   })
 })

--- a/api/potlucks/potluck-router.test.js
+++ b/api/potlucks/potluck-router.test.js
@@ -27,7 +27,7 @@ describe("[GET] /api/potlucks", () => {
         .get("/api/potlucks")
         .set("Authorization", loginRes.body.token)
     })
-    it("responds with an array of potlucks if request headers authorization is valid", async () => {
+    it("responds with an array of potlucks if request headers authorization is valid", () => {
       expect(res.body).toHaveLength(2)
       expect(res.body[0] && res.body[1]).toHaveProperty("date")
       expect(res.body[0] && res.body[1]).toHaveProperty("location")
@@ -38,6 +38,17 @@ describe("[GET] /api/potlucks", () => {
     })
     it("responds with the status code 200", () => {
       expect(res.status).toBe(200)
+    })
+  })
+  describe("token required", () => {
+    let res
+    beforeEach(async () => {
+      res = await request(server)
+        .get("/api/potlucks")
+    })
+    it("responds with the message 'token required'", () => {
+      const expected = "token required"
+      expect(res.body.message).toMatch(expected)
     })
   })
 })

--- a/api/potlucks/potluck-router.test.js
+++ b/api/potlucks/potluck-router.test.js
@@ -61,7 +61,7 @@ describe("[GET] - /api/potlucks", () => {
         .get("/api/potlucks")
         .set("Authorization", "junk")
     })
-    it("responds with the message 'token required'", () => {
+    it("responds with the message 'invalid token'", () => {
       const expected = /invalid token/i
       expect(res.body.message).toMatch(expected)
     })
@@ -105,6 +105,21 @@ describe("[GET] - /api/potlucks/:potluck_id", () => {
     })
     it("responds with the message 'token required'", () => {
       const expected = /token required/i
+      expect(res.body.message).toMatch(expected)
+    })
+    it("responds with the status code 401", () => {
+      expect(res.status).toBe(401)
+    })
+  })
+  describe("requesting with an invalid token", () => {
+    let res
+    beforeEach(async () => {
+      res = await request(server)
+        .get("/api/potlucks/:potluck_id")
+        .set("Authorization", "megaJunk")
+    })
+    it("responds with the message 'invalid token'", () => {
+      const expected = /invalid token/i
       expect(res.body.message).toMatch(expected)
     })
     it("responds with the status code 401", () => {

--- a/api/potlucks/potluck-router.test.js
+++ b/api/potlucks/potluck-router.test.js
@@ -1,0 +1,43 @@
+const request = require('supertest')
+const server = require('../server')
+const db = require('../data/db-config')
+
+beforeAll(async () => {
+  await db.migrate.rollback()
+  await db.migrate.latest()
+})
+beforeEach(async () => {
+  await db.seed.run()
+})
+afterAll(async () => {
+  await db.destroy()
+})
+
+describe("[GET] /api/potlucks", () => {
+  describe("success", () => {
+    let res
+    beforeEach(async () => {
+      const loginRes = await request(server)
+        .post("/api/auth/login")
+        .send({
+          username: "sam",
+          password: "1234"
+        })
+      res = await request(server)
+        .get("/api/potlucks")
+        .set("Authorization", loginRes.body.token)
+    })
+    it("responds with an array of potlucks if request headers authorization is valid", async () => {
+      expect(res.body).toHaveLength(2)
+      expect(res.body[0] && res.body[1]).toHaveProperty("date")
+      expect(res.body[0] && res.body[1]).toHaveProperty("location")
+      expect(res.body[0] && res.body[1]).toHaveProperty("time")
+      expect(res.body[0] && res.body[1]).toHaveProperty("potluck_name")
+      expect(res.body[0] && res.body[1]).toHaveProperty("potluck_id")
+      expect(res.body[0] && res.body[1]).toHaveProperty("user_id")
+    })
+    it("responds with the status code 200", () => {
+      expect(res.status).toBe(200)
+    })
+  })
+})

--- a/api/potlucks/potlucks-router.js
+++ b/api/potlucks/potlucks-router.js
@@ -1,6 +1,9 @@
 const router = require('express').Router();
 const Potlucks = require('./potlucks-model');
-const { checkPotluckId } = require('./potluck-middleware');
+const {
+  checkPotluckId,
+  validateAddGuestPayload,
+} = require('./potluck-middleware');
 
 // [GET] /api/potlucks
 router.get('/', (req, res, next) => {
@@ -58,9 +61,9 @@ router.get('/:potluck_id/foods', checkPotluckId, async (req, res, next) => {
 });
 
 // [POST] /api/potlucks/:potluck_id/guests
-router.post('/:potluck_id/guests', checkPotluckId, async (req, res, next) => {
+router.post('/:potluck_id/guests', validateAddGuestPayload, checkPotluckId, async (req, res, next) => {
   try {
-    const guest = await Potlucks.addGuest(req.params.potluck_id, req.body);
+    const guest = await Potlucks.addGuest(req.params.potluck_id, req.body.guest);
     res.status(201).json(guest);
   } catch (err) {
     next(err);

--- a/api/potlucks/potlucks-router.js
+++ b/api/potlucks/potlucks-router.js
@@ -61,14 +61,16 @@ router.get('/:potluck_id/foods', checkPotluckId, async (req, res, next) => {
 });
 
 // [POST] /api/potlucks/:potluck_id/guests
-router.post('/:potluck_id/guests', validateAddGuestPayload, checkPotluckId, async (req, res, next) => {
-  try {
-    const guest = await Potlucks.addGuest(req.params.potluck_id, req.body.guest);
-    res.status(201).json(guest);
-  } catch (err) {
-    next(err);
-  }
-});
+router.post('/:potluck_id/guests',
+  checkPotluckId,
+  validateAddGuestPayload, async (req, res, next) => {
+    try {
+      const guest = await Potlucks.addGuest(req.params.potluck_id, req.body.guest);
+      res.status(201).json(guest);
+    } catch (err) {
+      next(err);
+    }
+  });
 
 // [POST] /api/potlucks/:potluck_id/foods
 router.post('/:potluck_id/foods', checkPotluckId, async (req, res, next) => {

--- a/api/server.js
+++ b/api/server.js
@@ -6,7 +6,7 @@ const cors = require('cors');
 const authRouter = require('./auth/auth-router');
 const userRouter = require('./users/users-router');
 const potluckRouter = require('./potlucks/potlucks-router');
-// const restricted = require('./middleware/restricted');
+const restricted = require('./middleware/restricted');
 
 const server = express();
 server.use(express.json());
@@ -14,8 +14,8 @@ server.use(helmet());
 server.use(cors());
 
 // Routes
-server.use('/api/potlucks', potluckRouter);
-server.use('/api/users', userRouter);
+server.use('/api/potlucks', restricted, potluckRouter);
+server.use('/api/users', restricted, userRouter);
 server.use('/api/auth', authRouter);
 
 //eslint-disable-next-line

--- a/api/users/users-middleware.js
+++ b/api/users/users-middleware.js
@@ -1,4 +1,3 @@
-const Potlucks = require('../potlucks/potlucks-model');
 const Users = require("./users-model")
 
 const checkPotluck = (req, res, next) => {
@@ -16,7 +15,7 @@ const checkPotluck = (req, res, next) => {
   next();
 };
 
-async function checkIfUserExists(req, res, next) {
+async function findUserByUsername(req, res, next) {
   const { username } = req.body
   if (!username) {
     return next({
@@ -37,5 +36,5 @@ async function checkIfUserExists(req, res, next) {
 
 module.exports = {
   checkPotluck,
-  checkIfUserExists,
+  findUserByUsername
 };

--- a/api/users/users-router.js
+++ b/api/users/users-router.js
@@ -3,7 +3,7 @@ const Users = require('./users-model');
 const Potlucks = require('../potlucks/potlucks-model');
 const {
   checkPotluck,
-  checkIfUserExists,
+  findUserByUsername,
 } = require('./users-middleware');
 
 // [GET] /api/users
@@ -12,7 +12,7 @@ router.get('/', async (req, res) => {
 });
 
 // [POST] /api/users/
-router.post('/', checkIfUserExists, async (req, res, next) => {
+router.post('/', findUserByUsername, async (req, res, next) => {
   const { user_id } = req.user
   try {
     res.status(200).json({ user_id });
@@ -32,7 +32,7 @@ router.get('/:user_id', async (req, res) => {
 });
 
 // [GET] /api/users/:user_id/potlucks
-router.get('/:user_id/potlucks', checkIfUserExists, async (req, res, next) => {
+router.get('/:user_id/potlucks', findUserByUsername, async (req, res, next) => {
   try {
     const potlucks = await Users.getByIdPotlucks(req.params.user_id);
     res.json(potlucks);


### PR DESCRIPTION
## Additions:
**Test coverage for:**
- `[GET] /api/potlucks`
- `[GET] /api/potlucks/:potluck_id`
- `[GET] /api/potlucks/:potluck_id/guests`
- `[GET] /api/potlucks/:potluck_id/foods`
- `[POST] /api/potlucks/:potluck_id/guests`

**Side Addition:**
- New `validateAddGuestPayload` middleware function for `[POST] /api/potlucks/:potluck_id/guests`

### Changes:
- Renamed `checkIfUserExists` to `findUserByUsername` inside `potluck-middleware.js`
- Updated `README.md`
- Modified multiple seed tables
- **Restricted both the `potlucks` and `users` routers**